### PR TITLE
WIP: Handles socket reuse

### DIFF
--- a/policyd_rate_limit/config.py
+++ b/policyd_rate_limit/config.py
@@ -84,3 +84,6 @@ smtp_server = ("localhost", 25)
 smtp_starttls = False
 # Should we use credentials to connect to smtp_server ? if yes set ("user", "password"), else None
 smtp_credentials = None
+
+# The time in seconds before an unused socket gets closed
+delay_to_close = 300

--- a/policyd_rate_limit/policyd-rate-limit.yaml
+++ b/policyd_rate_limit/policyd-rate-limit.yaml
@@ -102,3 +102,6 @@ smtp_server: ["localhost", 25]
 smtp_starttls: False
 # Should we use credentials to connect to smtp_server ? if yes set ["user", "password"], else null
 smtp_credentials: null
+
+# The time in seconds before an unused socket gets closed
+delay_to_close: 300

--- a/policyd_rate_limit/policyd.py
+++ b/policyd_rate_limit/policyd.py
@@ -141,8 +141,7 @@ class Policyd(object):
                         self.close_connection(socket)
                         __to_rm.append(socket)
                 for socket in __to_rm:
-                    _ = self.last_used.pop(socket)
-
+                    self.last_used.pop(socket)
 
         except (KeyboardInterrupt, utils.Exit):
             for socket in list(self.socket_data_read.keys()):

--- a/policyd_rate_limit/utils.py
+++ b/policyd_rate_limit/utils.py
@@ -268,7 +268,7 @@ class _cursor(object):
     def del_db(cls):
         try:
             cls._db[threading.current_thread()].close()
-        except:
+        except Exception as e:
             pass
         try:
             del cls._db[threading.current_thread()]


### PR DESCRIPTION
@nitmir for review & testing, this patch should allow the reuse of any write socket after the write is fully done.

Rationale:
 * When a socket is done writing, it's removed from the write list, and remains in the read list, if an app sends another content on the socket, it'll be reused.
 * When a socket isn't used for a considerable amount of time, it's dropped.