### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/policyd_rate_limit/utils.py
+++ b/policyd_rate_limit/utils.py
@@ -15,7 +15,8 @@ import threading
 import collections
 import ipaddress
 import time
-import imp
+import importlib.util
+import importlib.machinery
 import pwd
 import grp
 import warnings
@@ -34,6 +35,18 @@ def ip_network(ip_str):
     except ipaddress.AddressValueError:
         return ipaddress.IPv6Network(ip_str)
 
+
+
+def load_source(modname, filename):
+    # Replacing imp.load_source() according to https://docs.python.org/3/whatsnew/3.12.html#imp
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 class Exit(Exception):
     pass
@@ -63,7 +76,7 @@ class Config(object):
                 try:
                     # compatibility with old config style in a python module
                     if config_file.endswith(".conf"):  # pragma: no cover (deprecated)
-                        self._config = imp.load_source('config', config_file)
+                        self._config = load_source('config', config_file)
                         warnings.warn(
                             (
                                 "New configuration use a .yaml file. "
@@ -71,7 +84,7 @@ class Config(object):
                             ),
                             stacklevel=3
                         )
-                        cache_file = imp.cache_from_source(config_file)
+                        cache_file = importlib.util.cache_from_source(config_file)
                         # remove the config pyc file
                         try:
                             os.remove(cache_file)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 setup(
     name='policyd-rate-limit',
-    version='1.2.0',
+    version='1.2.1',
     description=DESC,
     long_description=README,
     author='Valentin Samir',


### PR DESCRIPTION
policyd-rate-limit uses builtin module imp, which was removed from Python 3.12.

The changes required were minimal as it was only used in one place (first commit)

The second commit was added because without it pip installed the version from pypi. Maybe there is another solution but the invocation in Makefile did not install from the local tar archive until I bumped the version number. You probably do no want to merge it but I'm including it anyway.

Closes: #31 